### PR TITLE
Fix: disable the cron job on the backstage action

### DIFF
--- a/.github/workflows/backstage-catalog-helper.yml
+++ b/.github/workflows/backstage-catalog-helper.yml
@@ -1,8 +1,6 @@
 name: Backstage Catalog Info Helper
 on:
   workflow_dispatch:
-  schedule:
-    - cron: "0 0 * * *"
 
 jobs:
   update-catalog-info:


### PR DESCRIPTION
# Summary | Résumé

Disable the cron job that runs the Backstage Helper. Changes to the action's configuration are required to reenable it properly.